### PR TITLE
docs: NVIDIA Inception badge + note; fix branch-unification & staleness

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,8 @@
 # sidekick — local coding-agent orchestrator
 
 **Goal:** A local orchestrator that decomposes a high-level coding task, fans out to
-multiple **auto-approved Claude Code headless sessions** (each on its own git
-branch/worktree), shows live progress, and optimizes around measurable speed/accuracy
+multiple **auto-approved headless coding agents** — any LLM via LiteLLM (default
+`local-cpu`) or the native Claude Code binary, each on its own git branch/worktree, shows live progress, and optimizes around measurable speed/accuracy
 objectives. Inspired by the **Nous Hermes-Agent** architecture (skills/memory loop, RPC
 subagents, pluggable terminal backends) and grounded in **Raschka's six coding-agent
 components**.
@@ -10,17 +10,16 @@ components**.
 ## Substrate (verified)
 - Claude Code native binary at `$CLAUDE_CODE_EXECPATH` → headless via
   `claude -p --output-format stream-json --verbose`, auto-approval via
-  `--permission-mode acceptEdits` / `--allow-dangerously-skip-permissions`,
-  multi-agent via `--agents`, scoping via `--allowedTools` / `--add-dir`,
+  `--permission-mode acceptEdits` / `--allow-dangerously-skip-permissions`, scoping via `--allowedTools` / `--add-dir`,
   continuity via `--session-id` / `--resume`.
 - `git` worktrees give each agent an isolated branch (Hermes "terminal backend" analog).
-- Python 3.14 + uv + ruff (matches the sibling `vibexgen` project conventions).
+- Python >= 3.12 + uv + ruff (matches the sibling `vibexgen` project conventions).
 
 ## Architecture (maps Hermes ↔ Raschka)
 ```
 sidekick/
   sidekick/
-    __main__.py / cli.py     CLI: run | plan | status | metrics | bench
+    __main__.py / cli.py     CLI: run | plan | repl | voice | status | metrics | bench | gateway
     config.py                models, concurrency, paths, env
     repo_context.py          [Raschka #1] git status, tree, docs → workspace summary
     prompts/                 [Raschka #2] stable system-prefix fragments (cache reuse)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # sidekick
 
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE) ![Python](https://img.shields.io/badge/Python-3.12%2B-3776AB.svg) [![NVIDIA Inception](https://img.shields.io/badge/NVIDIA-Inception%20Program%20Member-76B900.svg)](https://www.nvidia.com/en-us/startups/)
+
+> **🚀 NVIDIA Inception Program Member** — ReDevOps is a member of the NVIDIA Inception Program, supporting startups advancing AI and accelerated computing. Membership provides access to NVIDIA technology, technical resources, and the startup ecosystem. It does not imply product endorsement by NVIDIA.
+
 A **local coding-agent orchestrator**. Give it a high-level task and it:
 
 1. decomposes the task into a **DAG of subtasks**,
@@ -219,7 +223,7 @@ sidekick repl --voice          # voice-driven interactive loop (great for the VS
 ```
 
 Speech-to-text goes through an **OpenAI-compatible `/audio/transcriptions`** endpoint, so
-it is provider-independent from the coding model (shared by the `claude`, `kimi`, … branches):
+it is provider-independent from the coding model (the same STT path is used for every provider):
 
 | Var | Default |
 |-----|---------|
@@ -310,9 +314,9 @@ this table.
 ## Delegation from another Claude Code session
 
 `sidekick` can be invoked **from inside another Claude Code session** so the
-parent session never spends its own context on the work. On this `selfhosted`
-branch the spawned sub-agents run on the local model (vLLM/llama.cpp `/v1`) by
-default; the parent Claude Code session shells out via a single CLI call and
+parent session never spends its own context on the work. By default the spawned
+sub-agents run on the local model (`local-cpu` — vLLM/llama.cpp `/v1` on `:8080`);
+the parent Claude Code session shells out via a single CLI call and
 parses a JSON envelope back.
 
 Two pieces:
@@ -320,7 +324,7 @@ Two pieces:
 1. **Install once, globally**:
 
    ```bash
-   uv tool install /mnt/backup/projects/sidekick
+   uv tool install --editable .
    ```
 
    Puts `sidekick` on `PATH` for every shell — every Claude Code session
@@ -328,11 +332,11 @@ Two pieces:
    pulling new changes:
 
    ```bash
-   uv tool install --reinstall /mnt/backup/projects/sidekick
+   uv tool install --reinstall --editable .
    ```
 
 2. **The user-level skill** at `~/.claude/skills/delegate-to-sidekick/SKILL.md`
-   (canonical copy in this branch at `examples/delegate-to-sidekick.SKILL.md`)
+   (canonical copy in the repo at `examples/delegate-to-sidekick.SKILL.md`)
    teaches any Claude Code session **when** to delegate, **how** to invoke,
    and **what envelope** to expect. Auto-discovered by Claude Code via the
    `~/.claude/skills/` user-skills dir — the parent session will see
@@ -352,10 +356,10 @@ sidekick --repo /abs/path/to/repo run "<task>" --json --no-vscode
   parent's IDE.
 
 The envelope carries `ok`, `n_accepted/n_total`, `n_merged`, the `backend` used
-(`selfhosted:<model>` or `claude:<model>` per the per-run `--provider` choice),
+(`<provider>:<model>` — e.g. `local-cpu:openai/local-model` — or `claude:<model>` per the per-run `--provider` choice),
 per-subtask `branch`, and the last 2 KB of each acceptance check's transcript.
 Enough for the parent to summarize and decide whether to follow up.
 
-On this branch the default backend is the local self-hosted model (vLLM/llama.cpp);
+The default backend is the local model (`local-cpu`, llama.cpp/vLLM on `:8080`);
 pass `--provider claude` to delegate to native Claude Code sub-agents instead. Either way
 the envelope shape is identical — only the `backend` field changes.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -3,6 +3,8 @@
 End-to-end validation via `sidekick bench` (3 disjoint subtasks, real auto-approved
 headless Claude sessions on `claude-haiku-4-5`, serial baseline vs orchestrated at N=3).
 
+> Note: `sidekick bench` now defaults to the local model (`local-cpu`); reproduce these `claude-haiku` numbers with `sidekick bench --provider claude`.
+
 Serial baseline **35.7s** → orchestrated **6.6s** (3 parallel auto-approved agents).
 
 | ID | Objective | Value | Target | Status |


### PR DESCRIPTION
Adds the NVIDIA Inception badge + note, and fixes docs against the unified LiteLLM backend on main: default provider is local-cpu (not a 'selfhosted branch'); backend field is <provider>:<model>; removes a hardcoded local install path; notes bench now defaults to local-cpu; and corrects PLAN.md (Python >=3.12, no --agents, full CLI verbs, any-LLM framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)